### PR TITLE
Connect to fullsend agent pipeline

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -1,0 +1,22 @@
+# fullsend shim workflow
+# Routes events to the reusable agent dispatch workflow in .fullsend.
+name: fullsend
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  dispatch:
+    uses: halfsend/.fullsend/.github/workflows/agent.yaml@main
+    with:
+      event_type: ${{ github.event_name }}
+      event_payload: ${{ toJSON(github.event) }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.FULLSEND_FULLSEND_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This PR adds a shim workflow that routes repository events to the fullsend agent dispatch workflow in the `.fullsend` config repo.

Once merged, issues, PRs, and comments in this repo will be handled by the fullsend agent pipeline.